### PR TITLE
udp mode

### DIFF
--- a/app/openvpn_client_lwt.ml
+++ b/app/openvpn_client_lwt.ml
@@ -110,8 +110,7 @@ let read_from_fd fd =
       let cs = Cstruct.of_bytes ~len:count buf in
       Logs.debug (fun m -> m "read %d bytes" count) ;
       Lwt.return cs)
-  |> Lwt_result.map_err (fun e ->
-      Rresult.R.msgf "read error %s" (Printexc.to_string e))
+  |> Lwt_result.map_err (fun e -> `Msg (Printexc.to_string e))
 
 let rec reader_tcp mvar fd =
   read_from_fd fd >>= function
@@ -135,8 +134,7 @@ let read_udp (sa, fd) =
       Lwt.return (Some cs)
     else
       Lwt.return None)
-  |> Lwt_result.map_err (fun e ->
-      Rresult.R.msgf "read error %s" (Printexc.to_string e))
+  |> Lwt_result.map_err (fun e -> `Msg (Printexc.to_string e))
 
 let rec reader_udp mvar r =
   read_udp r >>= function

--- a/app/openvpn_client_lwt.ml
+++ b/app/openvpn_client_lwt.ml
@@ -130,12 +130,13 @@ let read_udp =
   fun (sa, fd) ->
     Lwt_result.catch (
       Lwt_unix.recvfrom fd buf 0 bufsize [] >>= fun (count, sa') ->
-      if count = 0 then
-        Lwt.fail_with "end of file from server"
-      else if sa = sa' then
-        let cs = Cstruct.of_bytes ~len:count buf in
-        Logs.debug (fun m -> m "read %d bytes" count) ;
-        Lwt.return (Some cs)
+      if sa = sa' then
+        if count = 0 then
+          Lwt.fail_with "end of file from server"
+        else
+          let cs = Cstruct.of_bytes ~len:count buf in
+          Logs.debug (fun m -> m "read %d bytes" count) ;
+          Lwt.return (Some cs)
       else
         let pp_sockaddr ppf = function
           | Unix.ADDR_UNIX s -> Fmt.pf ppf "unix %s" s

--- a/app/openvpn_client_lwt.ml
+++ b/app/openvpn_client_lwt.ml
@@ -62,20 +62,42 @@ let rec write_to_fd fd data =
          Lwt_result.lift
            (Rresult.R.error_msgf "write error %s" (Printexc.to_string e)))
 
+let write_udp sa fd data =
+  Lwt.catch (fun () ->
+      Lwt_unix.sendto fd (Cstruct.to_bytes data) 0 (Cstruct.len data) [] sa >|= fun _ ->
+      Ok ())
+    (fun e ->
+       Lwt_result.lift
+         (Rresult.R.error_msgf "write error %s" (Printexc.to_string e)))
+
 let write_multiple_to_fd fd bufs =
-  match fd with
+  Lwt_list.fold_left_s (fun r buf ->
+      if r then
+        write_to_fd fd buf >|= function
+        | Ok () -> true
+        | Error `Msg msg ->
+          Logs.err (fun m -> m "error %s while writing" msg);
+          false
+      else
+        Lwt.return r)
+    true bufs
+
+let write_multiple_udp sa fd bufs =
+  Lwt_list.fold_left_s (fun r buf ->
+      if r then
+        write_udp sa fd buf >|= function
+        | Ok () -> true
+        | Error `Msg msg ->
+          Logs.err (fun m -> m "error %s while writing" msg);
+          false
+      else
+        Lwt.return r)
+    true bufs
+
+let transmit data = function
+  | Some `Tcp fd -> write_multiple_to_fd fd data
+  | Some `Udp (sa, fd) -> write_multiple_udp sa fd data
   | None -> Lwt.return false
-  | Some fd ->
-    Lwt_list.fold_left_s (fun r buf ->
-        if r then
-          write_to_fd fd buf >|= function
-          | Ok () -> true
-          | Error `Msg msg ->
-            Logs.err (fun m -> m "error %s while writing" msg);
-            false
-        else
-          Lwt.return r)
-      true bufs
 
 let read_from_fd fd =
   Lwt_result.catch (
@@ -91,14 +113,40 @@ let read_from_fd fd =
   |> Lwt_result.map_err (fun e ->
       Rresult.R.msgf "read error %s" (Printexc.to_string e))
 
-let rec reader mvar fd =
+let rec reader_tcp mvar fd =
   read_from_fd fd >>= function
   | Error `Msg msg ->
     Logs.err (fun m -> m "read error from remote %s" msg);
     Lwt_mvar.put mvar `Connection_failed
   | Ok data ->
     Lwt_mvar.put mvar (`Data data) >>= fun () ->
-    reader mvar fd
+    reader_tcp mvar fd
+
+let read_udp (sa, fd) =
+  Lwt_result.catch (
+    let bufsize = 2048 in
+    let buf = Bytes.create bufsize in
+    Lwt_unix.recvfrom fd buf 0 bufsize [] >>= fun (count, sa') ->
+    if count = 0 then
+      Lwt.fail_with "end of file from server"
+    else if sa = sa' then
+      let cs = Cstruct.of_bytes ~len:count buf in
+      Logs.debug (fun m -> m "read %d bytes" count) ;
+      Lwt.return (Some cs)
+    else
+      Lwt.return None)
+  |> Lwt_result.map_err (fun e ->
+      Rresult.R.msgf "read error %s" (Printexc.to_string e))
+
+let rec reader_udp mvar r =
+  read_udp r >>= function
+  | Error `Msg msg ->
+    Logs.err (fun m -> m "read error from remote %s" msg);
+    Lwt_mvar.put mvar `Connection_failed
+  | Ok Some data ->
+    Lwt_mvar.put mvar (`Data data) >>= fun () ->
+    reader_udp mvar r
+  | Ok None -> reader_udp mvar r
 
 let ts () = Mtime.Span.to_uint64_ns (Mtime_clock.elapsed ())
 
@@ -163,9 +211,19 @@ let connect_tcp ip port =
      TODO this will be fixed in upcoming PR to mirage-tuntap.
   *)
 
+let connect_udp ip port =
+  let dom =
+    Ipaddr.(Lwt_unix.(match ip with V4 _ -> PF_INET | V6 _ -> PF_INET6))
+  and unix_ip = Ipaddr_unix.to_inet_addr ip
+  and src_port = Randomconv.int16 Nocrypto.Rng.generate
+  in
+  let fd = Lwt_unix.(socket dom SOCK_DGRAM 0) in
+  Lwt_unix.(bind fd (ADDR_INET (Unix.inet_addr_any, src_port))) >|= fun () ->
+  Unix.ADDR_INET (unix_ip, port), fd
+
 type conn = {
   mutable o_client : Openvpn.t ;
-  mutable fd : Lwt_unix.file_descr option ;
+  mutable peer : ([ `Udp of Lwt_unix.sockaddr * Lwt_unix.file_descr | `Tcp of Lwt_unix.file_descr ]) option ;
   mutable est_switch : Lwt_switch.t ;
   data_mvar : Cstruct.t list Lwt_mvar.t ;
   est_mvar : (Openvpn.ip_config * int) Lwt_mvar.t ;
@@ -181,18 +239,26 @@ let handle_action conn = function
     resolve data >>= fun r ->
     let ev = match r with None -> `Resolve_failed | Some x -> `Resolved x in
     Lwt_mvar.put conn.event_mvar ev
-  | `Connect (ip, port, _proto) ->
+  | `Connect (ip, port, `Udp) ->
+    Lwt_switch.turn_off conn.est_switch >>= fun () ->
+    conn.est_switch <- Lwt_switch.create ();
+    Logs.app (fun m -> m "connecting udp %a" Ipaddr.pp ip);
+    connect_udp ip port >>= fun r ->
+    conn.peer <- Some (`Udp r);
+    Lwt.async (fun () -> reader_udp conn.event_mvar r);
+    Lwt_mvar.put conn.event_mvar `Connected
+  | `Connect (ip, port, `Tcp) ->
     Lwt_switch.turn_off conn.est_switch >>= fun () ->
     let sw = Lwt_switch.create () in
     conn.est_switch <- sw;
-    Logs.app (fun m -> m "connecting %a" Ipaddr.pp ip);
+    Logs.app (fun m -> m "connecting tcp %a" Ipaddr.pp ip);
     connect_tcp ip port >>= fun r ->
     if Lwt_switch.is_on sw then
       let ev = match r with
         | None -> `Connection_failed
         | Some fd ->
-          conn.fd <- Some fd;
-          Lwt.async (fun () -> reader conn.event_mvar fd);
+          conn.peer <- Some (`Tcp fd);
+          Lwt.async (fun () -> reader_tcp conn.event_mvar fd);
           `Connected
       in
       Lwt_mvar.put conn.event_mvar ev
@@ -201,13 +267,13 @@ let handle_action conn = function
       match r with None -> Lwt.return_unit | Some x -> safe_close x
     end
   | `Disconnect ->
-    begin match conn.fd with
+    begin match conn.peer with
       | None ->
         Logs.err (fun m -> m "cannot disconnect: no open connection");
         Lwt.return_unit
-      | Some fd ->
+      | Some `Tcp fd | Some `Udp (_, fd) ->
         Logs.warn (fun m -> m "disconnecting!");
-        conn.fd <- None;
+        conn.peer <- None;
         safe_close fd
     end
   | `Exit -> Lwt.fail_with "exit called"
@@ -232,7 +298,7 @@ let rec event conn =
      | [] -> ()
      | _ ->
        Lwt.async (fun () ->
-           (write_multiple_to_fd conn.fd outs >>= function
+           (transmit outs conn.peer >>= function
              | true -> Lwt.return_unit
              | false -> Lwt_mvar.put conn.event_mvar `Connection_failed)));
     (match action with
@@ -266,7 +332,7 @@ let send_recv conn config ip_config _mtu =
       | Ok (s', out) ->
         conn.o_client <- s';
         let open Lwt.Infix in
-        write_multiple_to_fd conn.fd [out] >>= fun sent ->
+        transmit [out] conn.peer >>= fun sent ->
         if sent then
           process_outgoing tun_fd
         else
@@ -284,7 +350,7 @@ let establish_tunnel config =
     and est_mvar = Lwt_mvar.create_empty ()
     and event_mvar = Lwt_mvar.create_empty ()
     in
-    let conn = { o_client ; fd = None ; est_switch = Lwt_switch.create () ;
+    let conn = { o_client ; peer = None ; est_switch = Lwt_switch.create () ;
                  data_mvar ; est_mvar ; event_mvar }
     in
     (* handle initial action *)

--- a/app/openvpn_client_lwt.ml
+++ b/app/openvpn_client_lwt.ml
@@ -131,12 +131,9 @@ let read_udp =
     Lwt_result.catch (
       Lwt_unix.recvfrom fd buf 0 bufsize [] >>= fun (count, sa') ->
       if sa = sa' then
-        if count = 0 then
-          Lwt.fail_with "end of file from server"
-        else
-          let cs = Cstruct.of_bytes ~len:count buf in
-          Logs.debug (fun m -> m "read %d bytes" count) ;
-          Lwt.return (Some cs)
+        let cs = Cstruct.of_bytes ~len:count buf in
+        Logs.debug (fun m -> m "read %d bytes" count) ;
+        Lwt.return (Some cs)
       else
         let pp_sockaddr ppf = function
           | Unix.ADDR_UNIX s -> Fmt.pf ppf "unix %s" s

--- a/mirage/openvpn_mirage.ml
+++ b/mirage/openvpn_mirage.ml
@@ -174,6 +174,9 @@ module Make (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PC
       Log.err (fun m -> m "no IPv6");
       Lwt_mvar.put conn.event_mvar `Connection_failed
     | `Connect (Ipaddr.V4 ip, port, `Udp) ->
+      (* we don't use the switch, but an earlier connection attempt may have used TCP *)
+      Lwt_switch.turn_off !conn_est >>= fun () ->
+      conn_est := Lwt_switch.create ();
       (* TODO we may wish to filter certain ports (< 1024) *)
       let our_port = Randomconv.int16 R.generate in
       let peer = our_port, ip, port in

--- a/src/config.ml
+++ b/src/config.ml
@@ -897,10 +897,10 @@ let a_not_implemented =
       string "rport" ;
       string "engine" ;
       (* TODO: *)
-      string "dhcp-option";
       string "redirect-gateway" ;
       string "up" ;
       string "dh" ;
+      string "explicit-exit-notify" ;
     ] <* a_whitespace >>= fun key ->
   take_while (function '\n' -> false | _ -> true) >>| fun rest ->
   Logs.warn (fun m ->m "IGNORING %S %S" key rest) ;

--- a/src/state.ml
+++ b/src/state.ml
@@ -62,6 +62,9 @@ type channel = {
   packets : int ;
 }
 
+let received_packet ch data =
+  { ch with packets = succ ch.packets ; bytes = Cstruct.len data + ch.bytes }
+
 let pp_channel ppf c =
   Fmt.pf ppf "channel %d %a@ started %Lu bytes %d packets %d@ transport %a"
     c.keyid pp_channel_state c.channel_st

--- a/src/state.ml
+++ b/src/state.ml
@@ -5,20 +5,25 @@ type key_source = {
   random2 : Cstruct.t ; (* 32 bytes *)
 }
 
+module IM = Map.Make(Int32)
+
 type transport = {
   my_message_id : int32 ; (* this starts from 0l, indicates the next to-be-send *)
   their_message_id : int32 ; (* the first should be 0l, indicates the next to-be-received *)
   last_acked_message_id : int32 ;
+  out_packets : (int64 * Cstruct.t) IM.t ;
 }
 
 let pp_transport ppf t =
-  Fmt.pf ppf "my message %lu@.their message %lu (acked %lu)"
+  Fmt.pf ppf "my message %lu@.their message %lu (acked %lu) out %d"
     t.my_message_id t.their_message_id t.last_acked_message_id
+    (IM.cardinal t.out_packets)
 
 let init_transport = {
   my_message_id = 0l ;
   their_message_id = 0l ;
   last_acked_message_id = 0l ;
+  out_packets = IM.empty ;
 }
 
 type keys = {


### PR DESCRIPTION
support UDP as transport next to TCP. when an ACK is received, the packet is dropped from the retransmission queue. when a timer occurs and no ACK was received, the control packet is retransmit. every incoming control packet is acked (as before).

testing plan was done locally at least -- it should be (a) reviewed and (b) maybe tested in a network with some loss of packets to figure out whether the retransmission is good.

from my memory (i may be wrong and should re-read the code):
- if one of our ACK is lost, we'll never send it again (since we fail to accept any incoming packet where seq <= last_received sequence number).
- we drop if seq > next_expected_sequence number -- so if a packet is lost all subsequent packets are dropped until the lost one is retransmit (this is not optimal)