### PR TITLE
More configuration options

### DIFF
--- a/src/openvpn.mli
+++ b/src/openvpn.mli
@@ -58,6 +58,10 @@ module Config : sig
     | Dev      : [`Null | `Tun of int option | `Tap of int option] k
     (** if Tap/Tun is [None], a device must be allocated dynamically. *)
 
+    | Dev_type : [ `Tun | `Tap ] k
+    (** The device type, use only if the device name used with Dev does not
+        begin with [tun] or [tap]. *)
+
     | Dhcp_disable_nbt: flag k
     | Dhcp_dns: Ipaddr.t list k
     | Dhcp_ntp: Ipaddr.t list k


### PR DESCRIPTION
the first commit is #10 (which imho is fine to merge as is). the topic of this PR is the second commit, adding some more configuration options:
- ~~`rport p` (replacing all _default_ port values (=1194) in remotes by p)~~
- typo fix
- dev_type (parses, part of the Config GADT, not used by logic)
- ignore `script_security`

the motivation for this change is actual configuration files I use and have on my disk //cc @cfcs