### PR TITLE
config: support for parsing secret (pre-shared static secret)

### DIFF
--- a/src/openvpn.mli
+++ b/src/openvpn.mli
@@ -148,6 +148,8 @@ module Config : sig
     | Route_metric : [`Default | `Metric of int] k
     (** Default metric for [Route _] directives *)
 
+    | Secret : (Cstruct.t * Cstruct.t * Cstruct.t * Cstruct.t) k
+
     | Tls_auth : ([`Incoming | `Outgoing] option
                   * Cstruct.t * Cstruct.t * Cstruct.t * Cstruct.t) k
     | Tls_cert     : X509.Certificate.t k


### PR DESCRIPTION
this unifies `<tls-auth>` and `secret` reader and writer... atm secret is only stored in the configuration map, but unused by the protocol logic