### PR TITLE
adapt to tcpip 4.1.0 API: fragments are now Lru.F.t -- and process returns a t as well

### DIFF
--- a/mirage-nat/config.ml
+++ b/mirage-nat/config.ml
@@ -15,7 +15,7 @@ let openvpn_handler =
       package "logs" ;
       package ~pin ~sublibs:["mirage"] "openvpn";
       package "mirage-kv";
-      package ~min:"2.0.0" "mirage-nat"
+      package ~min:"2.1.0" "mirage-nat"
     ]
   in
   foreign

--- a/openvpn.opam
+++ b/openvpn.opam
@@ -46,7 +46,7 @@ depends: [
   # mirage:
   "mirage-stack" {>= "2.0.0"}
   "mirage-protocols" {>= "4.0.0"}
-  "tcpip" {>= "4.0.0"}
+  "tcpip" {>= "4.1.0"}
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
 


### PR DESCRIPTION
sorry for breaking the API again.. ;)