### PR TITLE
Allow client configs that have client cert+key without user/pass (#24)

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -146,16 +146,14 @@ module Conf_map = struct
          | None | Some `Server -> Error "is not a TLS client"
          | Some `Client -> Ok ()) >>= fun () ->
         let _todo = ensure_not in
-        begin match find Auth_user_pass t,
-                    find Tls_cert t,
-                    find Tls_key t
-          with
-          | None, None, None -> Error "does not have user/password"
-          | (None | Some _), Some _, None -> Error "cert but no key given"
-          | (None |Some _), None, Some _ -> Error "key but no cert given"
-          | None,   Some _, Some _
-          | Some _, None  , None
-          | Some _, Some _, Some _ -> Ok ()
+        begin match find Auth_user_pass t, find Tls_cert t, find Tls_key t with
+          | Some _, None, None | None, Some _, Some _ -> Ok ()
+          | None, None, None ->
+            Error "does not have user/password, neither TLS certificate"
+          | Some _, Some _, Some _  ->
+            Error "both user/pass and TLS certificate provided"
+          | _ ->
+            Error "invalid combination of user/password and TLS key and certificate"
           (* ^-- TODO or has -pkcs12 *)
         end >>= fun () ->
         ensure_mem Cipher "client must specify 'cipher AES-256-CBC'"

--- a/src/openvpn.mli
+++ b/src/openvpn.mli
@@ -179,9 +179,6 @@ module Config : sig
         Indirectly also by [client]. *)
 
     | Tls_key      : X509.Private_key.t k
-    (** TODO Tls_key : X509.private_key * [`Incoming|`Outgoing] k
-        --key-direction governs this for inlined files
-        see comment in {!a_key} *)
 
     | Tls_timeout : int k
     (** Retransmit control channel packet after not receiving an ACK for

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -28,6 +28,7 @@ let minimal_config =
   |> add Connect_retry_max `Unlimited
   |> add Proto (None, `Udp)
   (* Minimal contents of actual config file: *)
+  |> add Cipher "AES-256-CBC"
   |> add Tls_mode `Client
   |> add Auth_user_pass ("testuser","testpass")
   |> add Remote ([`Ip (Ipaddr.of_string_exn "10.0.0.1"), 1194, `Udp])
@@ -37,6 +38,7 @@ let ok_minimal_client () =
   (* verify that we can parse a minimal good config. *)
   let basic =
     {|tls-client
+    cipher AES-256-CBC
     auth-user-pass [inline]
     <auth-user-pass>
 testuser
@@ -149,6 +151,7 @@ let rport_precedence () =
   let sample =
     {|
     tls-client
+    cipher AES-256-CBC
     auth-user-pass [inline]
     <auth-user-pass>
 testuser
@@ -168,6 +171,7 @@ testpass
   let expected =
     {|
     tls-client
+    cipher AES-256-CBC
     auth-user-pass [inline]
     <auth-user-pass>
 testuser


### PR DESCRIPTION
- This commit also ensures that the client specified a 'cipher' since if they did not, we end up asserting false in the 'mtu' function in src/state.ml
Fixes #24