### PR TITLE
instead of requiring 'int64' and 'Ptime.t' in all functions, require functions in constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ sudo: false
 env:
   global:
     - PACKAGE="openvpn"
-    - POST_INSTALL_HOOK="sh ./.travis-test-mirage.sh"
     - TESTS=false
     - DISTRO=alpine
   matrix:
-    - OCAML_VERSION=4.07 EXTRA_ENV="MIRAGE_MODE=qubes"
-    - OCAML_VERSION=4.08 EXTRA_ENV="MIRAGE_MODE=unix"
-    - OCAML_VERSION=4.09 EXTRA_ENV="MIRAGE_MODE=hvt"
+    - OCAML_VERSION=4.07 POST_INSTALL_HOOK="sh ./.travis-test-mirage.sh" EXTRA_ENV="MIRAGE_MODE=qubes"
+    - OCAML_VERSION=4.08 TESTS=true
+    - OCAML_VERSION=4.09 POST_INSTALL_HOOK="sh ./.travis-test-mirage.sh" EXTRA_ENV="MIRAGE_MODE=hvt"
+    - OCAML_VERSION=4.10 TESTS=true
 notifications:
   email: false

--- a/src/state.ml
+++ b/src/state.ml
@@ -235,6 +235,8 @@ type t = {
   config : Config.t ;
   linger : Cstruct.t ;
   rng : int -> Cstruct.t ;
+  ts : unit -> int64 ;
+  now : unit -> Ptime.t ;
   state : state ;
   session : session ;
   channel : channel ;
@@ -311,6 +313,8 @@ let channel_of_keyid keyid s =
 type server = {
   server_config : Config.t ;
   server_rng : int -> Cstruct.t ;
+  server_ts : unit -> int64 ;
+  server_now : unit -> Ptime.t ;
   server_hmac : Cstruct.t ;
   client_hmac : Cstruct.t ;
 }


### PR DESCRIPTION
this makes the API slighty simpler (less arguments) and uniform (rng/ts/now are all the same now), at the price of using a higher order.