### PR TITLE
Dev type regression

### DIFF
--- a/app/openvpn_client_lwt.ml
+++ b/app/openvpn_client_lwt.ml
@@ -162,7 +162,7 @@ let ts () = Mtime.Span.to_uint64_ns (Mtime_clock.elapsed ())
 let now () = Ptime_clock.now ()
 
 let resolve (name, ip_version) =
-  let res = Dns_client_lwt.create ~clock:ts () in
+  let res = Dns_client_lwt.create () in
   match ip_version with
   | `Ipv4 | `Any ->
     begin

--- a/app/openvpn_config_parser.ml
+++ b/app/openvpn_config_parser.ml
@@ -66,14 +66,14 @@ let () =
     match read_config_file fn with
     | Ok rules ->
       let outbuf = Buffer.create 2048 in
-      Fmt.pf (Format.formatter_of_buffer outbuf) "@[<v>%a@]\n" pp rules ;
+      Fmt.pf (Format.formatter_of_buffer outbuf) "@[<v>%a@]\n%!" pp rules ;
       Fmt.pr "%s%!" (pad_output (Buffer.contents outbuf)) ;
       Logs.info (fun m -> m "Read %d entries!" (cardinal rules)) ;
       (* The output was printed, now we generate a warning on stderr
        * if our self-testing fails: *)
       begin match
           parse_client ~string_of_file:(fun _fn -> assert false)
-            (Fmt.strf "%a" pp rules) with
+            (Buffer.contents outbuf) with
       | Error `Msg s->
         Logs.err (fun m ->m "self-test failed to parse: %s" s);
         exit 2

--- a/app/openvpn_config_parser.ml
+++ b/app/openvpn_config_parser.ml
@@ -22,7 +22,42 @@ let read_config_file fn =
   | Ok str -> parse_client ~string_of_file str
   | Error _ as e -> e
 
+let alignment_header =
+  {|#############
+# IMPORTANT:
+#  This OpenVPN configuration file has been padded with the comment below to
+#  ensure alignment on 512-byte boundaries for block device compatibility.
+#  That is a requirement for the MirageOS unikernels.
+#  If you modify it, please verify that the output of
+#       wc -c THIS.FILE
+#  is divisible by 512.
+#############
+|}
+
+let pad_output output =
+  let rec pad acc = function
+    | 0 -> acc
+    | n ->
+      let chunk = min n 77 in
+      let next = "\n" (* subtract length of this (= 1) below: *)
+                 ^ String.make (chunk - 1) '#'
+                 ^ acc in
+      pad next (n - chunk) in
+  let initial_padding = "\n\n" in
+  let ideal_size =
+    String.length alignment_header (* at beginning, before padding *)
+    + String.length initial_padding (* between padding and config contents *)
+    + String.length output in
+  let padding_size = 512 - (ideal_size mod 512) in
+  alignment_header ^ (pad initial_padding padding_size) ^ output
+
 let () =
+  (* Testing code for pad_output: *)
+  (*for i = 0 to 5000 do
+    assert (let res = pad_output (String.make i 'a') in
+            0 = String.length res mod 512)
+    done ; ignore (exit 0) ;
+  *)
   if not !Sys.interactive then begin
     Fmt_tty.setup_std_outputs () ;
     Logs.set_reporter (Logs_fmt.reporter());
@@ -30,9 +65,12 @@ let () =
     let fn = Sys.argv.(1) in
     match read_config_file fn with
     | Ok rules ->
-      Fmt.pr "@[<v>%a@]\n" pp rules ;
-      Logs.info (fun m -> m "Read %d entries!"
-                    (cardinal rules)) ;
+      let outbuf = Buffer.create 2048 in
+      Fmt.pf (Format.formatter_of_buffer outbuf) "@[<v>%a@]\n" pp rules ;
+      Fmt.pr "%s%!" (pad_output (Buffer.contents outbuf)) ;
+      Logs.info (fun m -> m "Read %d entries!" (cardinal rules)) ;
+      (* The output was printed, now we generate a warning on stderr
+       * if our self-testing fails: *)
       begin match
           parse_client ~string_of_file:(fun _fn -> assert false)
             (Fmt.strf "%a" pp rules) with

--- a/mirage/openvpn_mirage.ml
+++ b/mirage/openvpn_mirage.ml
@@ -214,7 +214,7 @@ module Server (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.
 end
 
 module Make (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) = struct
-  module DNS = Dns_client_mirage.Make(R)(M)(S)
+  module DNS = Dns_client_mirage.Make(R)(T)(M)(S)
   module TCP = S.TCPV4
   module UDP = S.UDPV4
 

--- a/openvpn.opam
+++ b/openvpn.opam
@@ -40,7 +40,7 @@ depends: [
   "ptime"
   "rresult"
   "tls" {>= "0.11.0"}
-  "dns-client" {>= "4.0.0"}
+  "dns-client" {>= "4.5.0"}
   "x509" {>= "0.10.0"}
   "duration"
 

--- a/openvpn.opam
+++ b/openvpn.opam
@@ -24,7 +24,7 @@ depends: [
   "logs"     { >= "0.6.2" }
   "rresult"  { >= "0.6.0" }
 
-  "angstrom"
+  "angstrom" { < "0.14.0" }
   "cstruct"  { >= "4.0.0" }
   "cmdliner"
   "domain-name" { >= "0.2.0" }

--- a/src/config.ml
+++ b/src/config.ml
@@ -1451,9 +1451,14 @@ let parse_next (effect:parser_effect) initial_state : (parser_state, 'err) resul
             List.fold_left (fun (typs, nams, other) -> function
                 | `Dev_type typ -> (typ::typs), nams, other
                 | `Dev name -> typs, (name::nams), other
-                | o -> typs, nams, (o::other))
+                | o -> typs, nams, (o::other)
+                (* o::other reverses the list, in order to keep
+                   Remote and other order-sensitive stanzas intact
+                   we need to List.rev the [tl] list. *)
+              )
               ([], [], []) (current :: tl)
           in
+          let tl = List.rev tl in (* Fix [tl] ordering *)
           begin match typs, names with
             | [typ], [name] ->
               (* custom named tun/tap device: *)

--- a/src/config.ml
+++ b/src/config.ml
@@ -1176,11 +1176,24 @@ let eq : eq = { f = fun (type x) (k: x k) (v:x) (v2:x) ->
       | Tls_auth, (dir, a,b,c,d), (dir', a',b',c',d') ->
         dir = dir' && Cstruct.equal a a' && Cstruct.equal b b'
         && Cstruct.equal c c' && Cstruct.equal d d'
+      | Remote, remotes_lst, remotes_lst2 ->
+        List.for_all2 (fun (a,port1,proto1) (b,port2,proto2) ->
+            port1 = port2 && proto1 = proto2
+            && match a,b with
+            | `Domain (host_a, ipv_a),
+              `Domain (host_b, ipv_b) ->
+              ipv_a = ipv_b && Domain_name.equal host_a host_b
+            | `Ip a , `Ip b ->
+              0 = Ipaddr.compare a b
+            | (`Domain _ | `Ip _),
+              (`Domain _ | `Ip _) -> false
+          ) remotes_lst remotes_lst2
       | _ ->     (*TODO non-polymorphic comparison*)
         let eq = (v = v2) in
         Logs.debug
-          (fun m -> m "eq self-test: @[<v>%a@,<>@,%a@]"
+          (fun m -> m "eq self-test: @[<v>%a@, %s @,%a@]"
               pp (singleton k v)
+              (if true then "=" else "<>")
               pp (singleton k v2)) ;
         eq
     end }


### PR DESCRIPTION
This fixes an annoying regression where the `dev-type` parser would reverse `tl`, causing the `Remote` order to jump around.

It's also got a bugfix for https://github.com/roburio/openvpn/pull/54/files where I had missed `%!` at the end of `Fmt.pf`, causing it to leave out the last line of the config.
