### PR TITLE
updates of tls (0.13+), dns (5.0+), and stack (use V4V6 now)

### DIFF
--- a/mirage-client/config.ml
+++ b/mirage-client/config.ml
@@ -14,7 +14,7 @@ let openvpn_handler =
   in
   foreign
     ~packages
-    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4 @-> kv_ro @-> job)
+    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4v6 @-> kv_ro @-> job)
 
 let () =
-  register "ovpn-client" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4 default_network $ data ]
+  register "ovpn-client" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4v6 default_network $ data ]

--- a/mirage-client/unikernel.ml
+++ b/mirage-client/unikernel.ml
@@ -8,7 +8,7 @@
 
 open Lwt.Infix
 
-module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) (FS: Mirage_kv.RO) = struct
+module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) (FS: Mirage_kv.RO) = struct
 
   module O = Openvpn_mirage.Make_stack(R)(M)(P)(T)(S)
   module I = Icmpv4.Make(O)

--- a/mirage-nat/config.ml
+++ b/mirage-nat/config.ml
@@ -22,7 +22,7 @@ let openvpn_handler =
   foreign
     ~packages
     "Unikernel.Main"
-    (random @-> mclock @-> pclock @-> time @-> stackv4 @-> network @-> ethernet @-> arpv4 @-> ipv4 @-> kv_ro @-> job)
+    (random @-> mclock @-> pclock @-> time @-> stackv4v6 @-> network @-> ethernet @-> arpv4 @-> ipv4 @-> kv_ro @-> job)
 
 let () =
-  register "ovpn-nat" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4 default_network $ private_netif $ private_ethernet $ private_arp $ private_ipv4 $ data ]
+  register "ovpn-nat" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4v6 default_network $ private_netif $ private_ethernet $ private_arp $ private_ipv4 $ data ]

--- a/mirage-nat/unikernel.ml
+++ b/mirage-nat/unikernel.ml
@@ -9,8 +9,8 @@
 open Lwt.Infix
 
 module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S)
-    (S : Mirage_stack.V4)
-    (N : Mirage_net.S) (E : Mirage_protocols.ETHERNET) (A : Mirage_protocols.ARP) (I : Mirage_protocols.IPV4)
+    (S : Mirage_stack.V4V6)
+    (N : Mirage_net.S) (E : Mirage_protocols.ETHERNET) (A : Mirage_protocols.ARP) (_ : Mirage_protocols.IPV4)
     (FS: Mirage_kv.RO) = struct
 
   module O = Openvpn_mirage.Make(R)(M)(P)(T)(S)

--- a/mirage-router/config.ml
+++ b/mirage-router/config.ml
@@ -21,7 +21,7 @@ let openvpn_handler =
   in
   foreign
     ~packages
-    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4 @-> network @-> ethernet @-> arpv4 @-> ipv4 @-> kv_ro @-> job)
+    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4v6 @-> network @-> ethernet @-> arpv4 @-> ipv4 @-> kv_ro @-> job)
 
 let () =
-  register "ovpn-router" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4 default_network $ private_netif $ private_ethernet $ private_arp $ private_ipv4 $ data ]
+  register "ovpn-router" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4v6 default_network $ private_netif $ private_ethernet $ private_arp $ private_ipv4 $ data ]

--- a/mirage-router/unikernel.ml
+++ b/mirage-router/unikernel.ml
@@ -31,7 +31,7 @@
 
 open Lwt.Infix
 
-module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4)
+module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6)
     (N : Mirage_net.S) (E : Mirage_protocols.ETHERNET) (A : Mirage_protocols.ARP) (I : Mirage_protocols.IPV4) (FS: Mirage_kv.RO) = struct
 
   module O = Openvpn_mirage.Make(R)(M)(P)(T)(S)

--- a/mirage-server/config.ml
+++ b/mirage-server/config.ml
@@ -16,7 +16,7 @@ let openvpn_handler =
   in
   foreign
     ~packages
-    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4 @-> kv_ro @-> job)
+    "Unikernel.Main" (random @-> mclock @-> pclock @-> time @-> stackv4v6 @-> kv_ro @-> job)
 
 let () =
-  register "ovpn-server" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4 default_network $ data ]
+  register "ovpn-server" [openvpn_handler $ default_random $ default_monotonic_clock $ default_posix_clock $ default_time $ generic_stackv4v6 default_network $ data ]

--- a/mirage-server/unikernel.ml
+++ b/mirage-server/unikernel.ml
@@ -1,6 +1,6 @@
 open Lwt.Infix
 
-module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) (FS: Mirage_kv.RO) = struct
+module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) (FS: Mirage_kv.RO) = struct
 
   module O = Openvpn_mirage.Server(R)(M)(P)(T)(S)
 

--- a/mirage/openvpn_mirage.mli
+++ b/mirage/openvpn_mirage.mli
@@ -7,7 +7,7 @@
     - established ++ read on connection -> handle + forward/write to destination
 
 *)
-module Server (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Server (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
   type t
 
   val connect : Openvpn.Config.t -> S.t -> t
@@ -15,7 +15,7 @@ module Server (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.
   val write : t -> Ipaddr.V4.t -> Cstruct.t -> unit Lwt.t
 end
 
-module Make (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Make (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
   type t
 
   val mtu : t -> int
@@ -32,7 +32,7 @@ module Make (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PC
   val write : t -> Cstruct.t -> bool Lwt.t
 end
 
-module Make_stack (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) : sig
+module Make_stack (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (P : Mirage_clock.PCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4V6) : sig
   include Mirage_protocols.IPV4
 
   val connect : Openvpn.Config.t -> S.t ->

--- a/openvpn.opam
+++ b/openvpn.opam
@@ -10,7 +10,7 @@ maintainer:   ["robur"]
 license:      "AGPL"
 
 build: [
-  ["dune" "subst" ] {pinned}
+  ["dune" "subst" ] {dev}
   ["dune" "build"   "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
@@ -39,9 +39,9 @@ depends: [
   "mirage-crypto-rng" {>= "0.8.0"}
   "ptime"
   "rresult"
-  "tls" {>= "0.11.0"}
-  "dns-client" {>= "4.5.0"}
-  "x509" {>= "0.10.0"}
+  "tls" {>= "0.13.0"}
+  "dns-client" {>= "5.0.0"}
+  "x509" {>= "0.13.0"}
   "duration"
 
   "tuntap" {>= "1.8.1"}
@@ -50,7 +50,7 @@ depends: [
   "mtime"
   "randomconv"
   # mirage:
-  "mirage-stack" {>= "2.0.0"}
+  "mirage-stack" {>= "2.2.0"}
   "mirage-protocols" {>= "5.0.0"}
   "tcpip" {>= "4.1.0"}
   "mirage-random" {>= "2.0.0"}


### PR DESCRIPTION
the result is that the unikernels are now supporting IPv6